### PR TITLE
Configured Svelte to use the same localhost address as Rails

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:3000'
+    }
+  }
 });


### PR DESCRIPTION
Configured Svelte to use the same localhost as the Rails backend